### PR TITLE
Upgrade to Java 8, eliminate Guava

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <java.minimum.version>1.8</java.minimum.version>
-        <aws.version>1.11.407</aws.version>
+        <aws.version>1.11.537</aws.version>
     </properties>
 
     <dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5,17 +5,17 @@
     <parent>
         <groupId>com.bazaarvoice.commons</groupId>
         <artifactId>bv-opensource-super-pom</artifactId>
-        <version>1.4</version>
+        <version>1.5</version>
         <relativePath />
     </parent>
 
     <groupId>com.bazaarvoice.awslocal</groupId>
     <artifactId>parent</artifactId>
-    <version>1.5-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
-        <java.minimum.version>1.7</java.minimum.version>
+        <java.minimum.version>1.8</java.minimum.version>
         <aws.version>1.11.407</aws.version>
     </properties>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -37,14 +37,9 @@
                 <version>3.1</version>
             </dependency>
             <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>15.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.4</version>
+                <version>1.7.26</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.bazaarvoice.awslocal</groupId>
         <artifactId>parent</artifactId>
-        <version>1.5-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
         <relativePath>parent/pom.xml</relativePath>
     </parent>
 

--- a/sns/pom.xml
+++ b/sns/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.bazaarvoice.awslocal</groupId>
         <artifactId>parent</artifactId>
-        <version>1.5-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/sns/pom.xml
+++ b/sns/pom.xml
@@ -21,10 +21,6 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/sns/src/main/java/com/bazaarvoice/awslocal/sns/InMemorySNS.java
+++ b/sns/src/main/java/com/bazaarvoice/awslocal/sns/InMemorySNS.java
@@ -25,7 +25,7 @@ import com.amazonaws.services.sns.model.UnsubscribeResult;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
-import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 public class InMemorySNS extends AbstractAmazonSNS {
@@ -42,6 +43,7 @@ public class InMemorySNS extends AbstractAmazonSNS {
 
     private Map<String, List<String>> _subscriptionsForTopic = new HashMap<>();
     private Map<String, Subscription> _subscriptionsByArn = new HashMap<>();
+    private Random _random = new Random();
 
     private AmazonSQS _sqsClient;
 
@@ -49,10 +51,8 @@ public class InMemorySNS extends AbstractAmazonSNS {
         _sqsClient = sqsClient;
         for (Subscription subscription : subscriptions) {
             _subscriptionsByArn.put(subscription.getSubscriptionArn(), subscription);
-            if (!_subscriptionsForTopic.containsKey(subscription.getTopicArn())) {
-                _subscriptionsForTopic.put(subscription.getTopicArn(), new ArrayList<String>());
-            }
-            _subscriptionsForTopic.get(subscription.getTopicArn()).add(subscription.getSubscriptionArn());
+            _subscriptionsForTopic.computeIfAbsent(subscription.getTopicArn(), key -> new ArrayList<>())
+                    .add(subscription.getSubscriptionArn());
         }
     }
 
@@ -62,24 +62,17 @@ public class InMemorySNS extends AbstractAmazonSNS {
         if (!_subscriptionsForTopic.containsKey(topicArn)) {
             throw new NotFoundException("no such topic " + topicArn);
         }
-        List<Subscription> topicSubscriptions = _subscriptionsForTopic.get(topicArn).stream()
-                .map(key -> {
-                    Subscription result = _subscriptionsByArn.get(key);
-                    if (result == null && !_subscriptionsByArn.containsKey(key)) {
-                        throw new IllegalArgumentException("Missing subscription for arn: " + key);
-                    }
-                    return result;
-                })
-                .collect(Collectors.toList());
-        for (Subscription subscription : topicSubscriptions) {
-            String queueName = getLast(subscription.getEndpoint().split(":"));
-            String queueUrl = _sqsClient.
-                    getQueueUrl(new GetQueueUrlRequest().withQueueName(queueName)).
-                    getQueueUrl();
-            _sqsClient.sendMessage(new SendMessageRequest().
-                    withQueueUrl(queueUrl).
-                    withMessageBody(publishRequest.getMessage()));
-        }
+        _subscriptionsForTopic.get(topicArn).stream()
+                .map(_subscriptionsByArn::get)
+                .forEach(subscription -> {
+                    String queueName = StringUtils.substringAfterLast(subscription.getEndpoint(), ":");
+                    String queueUrl = _sqsClient.
+                            getQueueUrl(new GetQueueUrlRequest().withQueueName(queueName)).
+                            getQueueUrl();
+                    _sqsClient.sendMessage(new SendMessageRequest().
+                            withQueueUrl(queueUrl).
+                            withMessageBody(publishRequest.getMessage()));
+                });
         return new PublishResult();
     }
 
@@ -93,17 +86,26 @@ public class InMemorySNS extends AbstractAmazonSNS {
         if (!_subscriptionsForTopic.containsKey(topicArn)) {
             throw new InvalidParameterException("no such topic " + topicArn);
         }
-        String subscriptionArn = topicArn + ":" + RandomStringUtils.randomNumeric(7);
-        if (!_subscriptionsByArn.containsKey(subscriptionArn)) {
-            _subscriptionsByArn.put(subscriptionArn, new Subscription().
-                    withTopicArn(topicArn).
-                    withProtocol(protocol).
-                    withSubscriptionArn(subscriptionArn).
-                    withEndpoint(subscribeRequest.getEndpoint()));
-            _subscriptionsForTopic.get(topicArn).add(subscriptionArn);
+        String subscriptionArn = topicArn + ":" + nextSubscriptionSuffix();
+        while (_subscriptionsByArn.containsKey(subscriptionArn)) {
+            // Avoid ID collision by generating a new suffix
+            subscriptionArn = topicArn + ":" + nextSubscriptionSuffix();
         }
+        _subscriptionsByArn.put(subscriptionArn, new Subscription().
+                withTopicArn(topicArn).
+                withProtocol(protocol).
+                withSubscriptionArn(subscriptionArn).
+                withEndpoint(subscribeRequest.getEndpoint()));
+        _subscriptionsForTopic.get(topicArn).add(subscriptionArn);
 
         return new SubscribeResult().withSubscriptionArn(subscriptionArn);
+    }
+
+    /**
+     * @return some 7-digit numeral
+     */
+    private int nextSubscriptionSuffix() {
+        return 1000000 + _random.nextInt(9000000);
     }
 
     @Override
@@ -120,9 +122,7 @@ public class InMemorySNS extends AbstractAmazonSNS {
     public CreateTopicResult createTopic(CreateTopicRequest createTopicRequest) throws AmazonClientException {
         String topicArn = BASE_ARN + createTopicRequest.getName();
         CreateTopicResult result = new CreateTopicResult().withTopicArn(topicArn);
-        if (!_subscriptionsForTopic.containsKey(topicArn)) {
-            _subscriptionsForTopic.put(topicArn, new ArrayList<String>());
-        }
+        _subscriptionsForTopic.putIfAbsent(topicArn, new ArrayList<>());
         return result;
     }
 
@@ -140,13 +140,7 @@ public class InMemorySNS extends AbstractAmazonSNS {
         return new ListSubscriptionsByTopicResult().
                 withSubscriptions(_subscriptionsForTopic.get(listSubscriptionsByTopicRequest.getTopicArn()).stream()
                         .filter(_subscriptionsByArn.keySet()::contains)
-                        .map(key -> {
-                            Subscription result = _subscriptionsByArn.get(key);
-                            if (result == null && !_subscriptionsByArn.containsKey(key)) {
-                                throw new IllegalArgumentException("Missing subscription for arn: " + key);
-                            }
-                            return result;
-                        })
+                        .map(_subscriptionsByArn::get)
                         .collect(Collectors.toList()));
     }
 
@@ -171,10 +165,6 @@ public class InMemorySNS extends AbstractAmazonSNS {
     @Override
     public ListTopicsResult listTopics(ListTopicsRequest listTopicsRequest) throws AmazonClientException {
         return listTopics();
-    }
-
-    private static <T> T getLast(T[] array) {
-        return array.length > 0 ? array[array.length - 1] : null;
     }
 
 }

--- a/sns/src/test/java/com/bazaarvoice/awslocal/sns/TestUtils.java
+++ b/sns/src/test/java/com/bazaarvoice/awslocal/sns/TestUtils.java
@@ -1,7 +1,5 @@
 package com.bazaarvoice.awslocal.sns;
 
-import com.google.common.base.Throwables;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -13,7 +11,7 @@ public class TestUtils {
             directory.deleteOnExit(); // not sure if this works
             return directory;
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/sqs/pom.xml
+++ b/sqs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.bazaarvoice.awslocal</groupId>
         <artifactId>parent</artifactId>
-        <version>1.5-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/sqs/pom.xml
+++ b/sqs/pom.xml
@@ -21,10 +21,6 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/sqs/src/main/java/com/bazaarvoice/awslocal/sqs/DirectorySQS.java
+++ b/sqs/src/main/java/com/bazaarvoice/awslocal/sqs/DirectorySQS.java
@@ -137,9 +137,7 @@ public class DirectorySQS extends AbstractAmazonSQS {
         final String queueUrl = queue.getQueuePath().toUri().toString();
         //don't panic, this is reentrant
         synchronized (_queuesByUrl) {
-            if (!_queuesByUrl.containsKey(queueUrl)) {
-                _queuesByUrl.put(queueUrl, queue);
-            }
+            _queuesByUrl.putIfAbsent(queueUrl, queue);
         }
         try {
             queue.getQueuePath().register(_queuesWatcher, StandardWatchEventKinds.ENTRY_CREATE);

--- a/sqs/src/main/java/com/bazaarvoice/awslocal/sqs/DirectorySQSQueue.java
+++ b/sqs/src/main/java/com/bazaarvoice/awslocal/sqs/DirectorySQSQueue.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.ToLongFunction;
 
 /**
  * This class manages a single queue that is persisted in a particular directory.

--- a/sqs/src/main/java/com/bazaarvoice/awslocal/sqs/DirectorySQSQueue.java
+++ b/sqs/src/main/java/com/bazaarvoice/awslocal/sqs/DirectorySQSQueue.java
@@ -4,8 +4,6 @@ import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.ReceiptHandleIsInvalidException;
 import com.amazonaws.util.BinaryUtils;
 import com.amazonaws.util.Md5Utils;
-import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.Lists;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -21,10 +19,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.ToLongFunction;
 
 /**
  * This class manages a single queue that is persisted in a particular directory.
@@ -41,7 +42,13 @@ public class DirectorySQSQueue {
     private static final String SUFFIX = ".msg";
 
     private final Path _path;
-    private final PriorityBlockingQueue<MessageAccessor> _messageQueue = new PriorityBlockingQueue<>();
+    private final PriorityBlockingQueue<MessageAccessor> _messageQueue = new PriorityBlockingQueue<>(
+            /* PriorityBlockingQueue.DEFAULT_INITIAL_CAPACITY */ 11,
+            Comparator
+                    .<MessageAccessor>comparingLong(value -> value._visibilityTimeMillis)
+                    .thenComparing(value -> value._messageId)
+                    .thenComparingInt(value -> value._number)
+    );
     private final AtomicInteger _counter = new AtomicInteger(1);
 
     public DirectorySQSQueue(Path path)
@@ -98,7 +105,7 @@ public class DirectorySQSQueue {
     }
 
     public List<Message> receive(int maximumNumberOfMessages, int visibilityTimeout, int waitTime) throws IOException {
-        List<MessageAccessor> claimed = Lists.newArrayListWithCapacity(maximumNumberOfMessages);
+        List<MessageAccessor> claimed = new ArrayList<>(maximumNumberOfMessages);
 
         final long endTimeMillis = System.currentTimeMillis() + waitTime * 1000;
         boolean tryClaimAgain = false;
@@ -113,7 +120,7 @@ public class DirectorySQSQueue {
             tryClaimAgain = claimTo(claimed, visibilityTimeout, 0);
         }
 
-        List<Message> messages = Lists.newArrayListWithCapacity(claimed.size());
+        List<Message> messages = new ArrayList<>(claimed.size());
         for (MessageAccessor accessor : claimed) {
             _messageQueue.offer(accessor);
             messages.add(new Message().
@@ -203,7 +210,7 @@ public class DirectorySQSQueue {
         return new MessageAccessor(parts[0], Integer.parseInt(parts[1]), Long.parseLong(parts[2]));
     }
 
-    private class MessageAccessor implements Comparable<MessageAccessor> {
+    private class MessageAccessor {
         private final String _messageId;
         private final int _number;
         private final long _visibilityTimeMillis;
@@ -222,15 +229,6 @@ public class DirectorySQSQueue {
 
         public String getMessageId() {
             return _messageId;
-        }
-
-        @Override
-        public int compareTo(MessageAccessor that) {
-            return ComparisonChain.start()
-                    .compare(this._visibilityTimeMillis, that._visibilityTimeMillis)
-                    .compare(this._messageId, that._messageId)
-                    .compare(this._number, that._number)
-                    .result();
         }
 
         @Override

--- a/sqs/src/test/java/com/bazaarvoice/awslocal/sqs/TestSQSClient.java
+++ b/sqs/src/test/java/com/bazaarvoice/awslocal/sqs/TestSQSClient.java
@@ -19,7 +19,6 @@ import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.services.sqs.model.SendMessageResult;
-import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -228,7 +227,7 @@ public class TestSQSClient {
         CreateQueueResult createQueueResult = _amazonSQS.createQueue(new CreateQueueRequest(queueName));
         String queueUrl = createQueueResult.getQueueUrl();
 
-        List<String> requestedAttributes = ImmutableList.of("QueueArn");
+        List<String> requestedAttributes = Collections.singletonList("QueueArn");
         GetQueueAttributesResult getQueueAttributesResult = _amazonSQS.getQueueAttributes(new GetQueueAttributesRequest()
                 .withQueueUrl(queueUrl)
                 .withAttributeNames(requestedAttributes));

--- a/sqs/src/test/java/com/bazaarvoice/awslocal/sqs/TestUtils.java
+++ b/sqs/src/test/java/com/bazaarvoice/awslocal/sqs/TestUtils.java
@@ -1,7 +1,5 @@
 package com.bazaarvoice.awslocal.sqs;
 
-import com.google.common.base.Throwables;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -13,7 +11,7 @@ public class TestUtils {
             directory.deleteOnExit(); // not sure if this works
             return directory;
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 }


### PR DESCRIPTION
``Objects.firstNonNull`` was removed in [Guava 21](https://github.com/google/guava/wiki/Release21#commonbase), so we either need to update the dependency or remove it.  Seems simpler to upgrade the library to require Java 8, and just remove Guava altogether, so we don't have future compatibility problems.

Since we're breaking Java 7 compatibility, this forces a major version increment, per semantic versioning.